### PR TITLE
Simplify directory handling with set_current_dir approach

### DIFF
--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -49,77 +49,85 @@ fn collect_files_recursively(dir: &PathBuf) -> Result<Vec<PathBuf>> {
 /// Main function for the `guts add` command
 /// Adds files to the staging area (index)
 pub fn run(args: &AddArgs) -> Result<String> {
-    // Determine current directory to use
-    let current_dir = args
-        .dir
-        .clone()
-        .unwrap_or_else(|| std::env::current_dir().expect("failed to get current directory"));
-
-    // Check if we're in a git repository
-    if !simple_index::is_git_repository_from(Some(&current_dir))? {
-        return Err(anyhow!("fatal: not a git repository"));
+    // Set current directory context for TUI
+    let original_dir = std::env::current_dir()?;
+    if let Some(dir) = &args.dir {
+        std::env::set_current_dir(dir)?;
     }
-
-    let mut added_files = Vec::new();
-    let mut output = String::new();
-
-    // Load .gutsignore matcher
-    let matcher = IgnoreMatcher::from_gutsignore(&current_dir)
-        .unwrap_or_else(|_| IgnoreMatcher::empty());
-
-    // Process each requested file
-    for file_path in &args.files {
-        // Support for "." - add all files from current directory
-        if file_path.to_string_lossy() == "." {
-            let files = collect_files_recursively(&current_dir)?;
-            for file in files {
-                if matcher.is_ignored(&file, &current_dir) {
-                    continue;
-                }
-                simple_index::add_file_to_index_from(&file, Some(&current_dir))?;
-                added_files.push(file.display().to_string());
-            }
-            continue;
+    
+    let result = || -> Result<String> {
+        // Check if we're in a git repository
+        if !simple_index::is_git_repository()? {
+            return Err(anyhow!("fatal: not a git repository"));
         }
 
-        // Basic checks
-        if !file_path.exists() {
-            return Err(anyhow!(
-                "pathspec '{}' did not match any files",
-                file_path.display()
-            ));
-        }
+        let mut added_files = Vec::new();
+        let mut output = String::new();
+        let current_dir = std::env::current_dir()?;
 
-        if file_path.is_dir() {
-            // If it's a directory, add all files recursively
-            let files = collect_files_recursively(file_path)?;
-            for file in files {
-                if matcher.is_ignored(&file, &current_dir) {
-                    continue;
+        // Load .gutsignore matcher
+        let matcher = IgnoreMatcher::from_gutsignore(&current_dir)
+            .unwrap_or_else(|_| IgnoreMatcher::empty());
+
+        // Process each requested file
+        for file_path in &args.files {
+            // Support for "." - add all files from current directory
+            if file_path.to_string_lossy() == "." {
+                let files = collect_files_recursively(&current_dir)?;
+                for file in files {
+                    if matcher.is_ignored(&file, &current_dir) {
+                        continue;
+                    }
+                    simple_index::add_file_to_index(&file)?;
+                    added_files.push(file.display().to_string());
                 }
-                simple_index::add_file_to_index_from(&file, Some(&current_dir))?;
-                added_files.push(file.display().to_string());
-            }
-        } else {
-            // Skip if ignored
-            if matcher.is_ignored(file_path, &current_dir) {
                 continue;
             }
-            // Add the file to the JSON index
-            simple_index::add_file_to_index_from(file_path, Some(&current_dir))?;
-            added_files.push(file_path.display().to_string());
-        }
-    }
 
-    // Confirmation message
-    if added_files.len() == 1 {
-        output.push_str(&format!("Added: {}", added_files[0]));
-    } else {
-        output.push_str(&format!("Added {} files:", added_files.len()));
-        for file in &added_files {
-            output.push_str(&format!("\n  - {}", file));
-        }
-    }
+            // Basic checks
+            if !file_path.exists() {
+                return Err(anyhow!(
+                    "pathspec '{}' did not match any files",
+                    file_path.display()
+                ));
+            }
 
-    Ok(output)
+            if file_path.is_dir() {
+                // If it's a directory, add all files recursively
+                let files = collect_files_recursively(file_path)?;
+                for file in files {
+                    if matcher.is_ignored(&file, &current_dir) {
+                        continue;
+                    }
+                    simple_index::add_file_to_index(&file)?;
+                    added_files.push(file.display().to_string());
+                }
+            } else {
+                // Skip if ignored
+                if matcher.is_ignored(file_path, &current_dir) {
+                    continue;
+                }
+                // Add the file to the JSON index
+                simple_index::add_file_to_index(file_path)?;
+                added_files.push(file_path.display().to_string());
+            }
+        }
+
+        // Confirmation message
+        if added_files.len() == 1 {
+            output.push_str(&format!("Added: {}", added_files[0]));
+        } else {
+            output.push_str(&format!("Added {} files:", added_files.len()));
+            for file in &added_files {
+                output.push_str(&format!("\n  - {}", file));
+            }
+        }
+
+        Ok(output)
+    }();
+    
+    // Restore original directory
+    std::env::set_current_dir(&original_dir)?;
+    
+    result
 }

--- a/src/commands/commit.rs
+++ b/src/commands/commit.rs
@@ -35,7 +35,7 @@ pub fn run(args: &CommitArgs) -> Result<String> {
 
 fn run_commit(args: &CommitArgs) -> Result<String> {
     // Check if we're in a git repository
-    if !simple_index::is_git_repository_from(args.dir.as_ref())? {
+    if !simple_index::is_git_repository()? {
         return Err(anyhow::anyhow!("fatal: not a git repository"));
     }
 

--- a/src/commands/log.rs
+++ b/src/commands/log.rs
@@ -15,16 +15,19 @@ pub struct LogArgs {
 /// Entry point for the `guts log` command
 /// Traverses the commit chain from HEAD to root, printing each commit's SHA and first line of message.
 pub fn run(args: &LogArgs) -> Result<String> {
-    // Determine current directory to use
-    let current_dir = args
-        .dir
-        .clone()
-        .unwrap_or_else(|| std::env::current_dir().expect("failed to get current directory"));
-
-    // Check if we're in a git repository
-    if !simple_index::is_git_repository_from(args.dir.as_ref())? {
-        return Err(anyhow!("fatal: not a git repository"));
+    // Set current directory context for TUI
+    let original_dir = std::env::current_dir()?;
+    if let Some(dir) = &args.dir {
+        std::env::set_current_dir(dir)?;
     }
+    
+    let result = || -> Result<String> {
+        // Check if we're in a git repository
+        if !simple_index::is_git_repository()? {
+            return Err(anyhow!("fatal: not a git repository"));
+        }
+        
+        let current_dir = std::env::current_dir()?;
 
     // Use the standard .git directory
     let git_dir = current_dir.join(".git");
@@ -79,7 +82,13 @@ pub fn run(args: &LogArgs) -> Result<String> {
         }
     }
 
-    Ok(output)
+        Ok(output)
+    }();
+    
+    // Restore original directory
+    std::env::set_current_dir(&original_dir)?;
+    
+    result
 }
 
 

--- a/src/commands/rm.rs
+++ b/src/commands/rm.rs
@@ -48,10 +48,17 @@ fn remove_file_from_index(file_path: &PathBuf) -> Result<bool> {
 /// Main function for the `guts rm` command
 /// Removes files from working directory and index
 pub fn run(args: &RmArgs) -> Result<String> {
-    // Check if we're in a git repository
-    if !simple_index::is_git_repository_from(args.dir.as_ref())? {
-        return Err(anyhow!("fatal: not a git repository"));
+    // Set current directory context for TUI
+    let original_dir = std::env::current_dir()?;
+    if let Some(dir) = &args.dir {
+        std::env::set_current_dir(dir)?;
     }
+    
+    let result = || -> Result<String> {
+        // Check if we're in a git repository
+        if !simple_index::is_git_repository()? {
+            return Err(anyhow!("fatal: not a git repository"));
+        }
 
     let mut removed_files = Vec::new();
     let mut output = String::new();
@@ -100,5 +107,11 @@ pub fn run(args: &RmArgs) -> Result<String> {
         output.pop(); // Remove last newline
     }
 
-    Ok(output)
+        Ok(output)
+    }();
+    
+    // Restore original directory
+    std::env::set_current_dir(&original_dir)?;
+    
+    result
 }

--- a/src/commands/write_tree.rs
+++ b/src/commands/write_tree.rs
@@ -12,10 +12,17 @@ pub struct WriteTreeArgs {
 /// New version of write-tree that uses the simple JSON index
 /// Instead of reading the filesystem, reads the index to create the tree
 pub fn run(args: &WriteTreeArgs) -> Result<String> {
-    // Check if we're in a git repository
-    if !simple_index::is_git_repository_from(args.dir.as_ref())? {
-        return Err(anyhow::anyhow!("fatal: not a git repository"));
+    // Set current directory context for TUI
+    let original_dir = std::env::current_dir()?;
+    if let Some(dir) = &args.dir {
+        std::env::set_current_dir(dir)?;
     }
+    
+    let result = || -> Result<String> {
+        // Check if we're in a git repository
+        if !simple_index::is_git_repository()? {
+            return Err(anyhow::anyhow!("fatal: not a git repository"));
+        }
 
     // Load the JSON index
     let index = simple_index::SimpleIndex::load()?;
@@ -26,7 +33,13 @@ pub fn run(args: &WriteTreeArgs) -> Result<String> {
     // Write the tree object and return its hash
     let oid = hash::write_object(&tree)?;
 
-    Ok(oid)
+        Ok(oid)
+    }();
+    
+    // Restore original directory
+    std::env::set_current_dir(&original_dir)?;
+    
+    result
 }
 
 /// Build a Git tree object from the JSON index


### PR DESCRIPTION
- Remove complex _from functions from simple_index.rs
- Use simple set_current_dir() at start of each command
- Restore original directory after command execution
- Much cleaner and more maintainable approach
- Fixes TUI directory context issues